### PR TITLE
Refactor process flags method

### DIFF
--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -1,0 +1,17 @@
+import * as dom from 'dts-dom';
+
+export default class Guard {
+    /**
+     * Guards for types from `jsdoc` doclets.
+     */
+    static doclet = class {
+
+    };
+
+    /**
+     * Guards for types from `dts-dom`.
+     */
+    static dom = class {
+
+    };
+}

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -25,6 +25,33 @@ export default class Guard {
      */
     static dom = class {
         /**
+         * Guards for `Type`s.
+         */
+        static type = class {
+            /**
+             * Guards that the given `type` is of type `dom.NamedTypeReference`.
+             *
+             * @param {any | Type} type
+             *
+             * @return {type is NamedTypeReference}
+             */
+            static isNamedTypeReference(type: dom.Type): type is dom.NamedTypeReference {
+                return typeof type === 'object' && type.kind === 'name';
+            }
+
+            /**
+             * Guards that the given `type` is of type `dom.TypeParameter`.
+             *
+             * @param {any | Type} type
+             *
+             * @return {type is TypeParameter}
+             */
+            static isTypeParameter(type: dom.Type): type is dom.TypeParameter {
+                return typeof type === 'object' && type.kind === 'type-parameter';
+            }
+        };
+
+        /**
          * Guards that the given `element` is of type `dom.Parameter`.
          *
          * @param {any | Parameter} element

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -6,6 +6,17 @@ export default class Guard {
      */
     static doclet = class {
         /**
+         * Guards that the given `doclet` is of type `TDoclet`.
+         *
+         * @param {Object} doclet
+         *
+         * @return {doclet is TDoclet}
+         */
+        static isTDoclet(doclet: object): doclet is TDoclet {
+            return typeof doclet === 'object' && 'kind' in doclet;
+        }
+
+        /**
          * Guards that the given `doclet` is of type `IDocletProp`.
          *
          * @param {any | IDocletProp} doclet

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -12,6 +12,15 @@ export default class Guard {
      * Guards for types from `dts-dom`.
      */
     static dom = class {
-
+        /**
+         * Guards that the given `element` is of type `dom.Parameter`.
+         *
+         * @param {any | Parameter} element
+         *
+         * @return {element is Parameter}
+         */
+        static isParameter(element: any | dom.Parameter): element is dom.Parameter {
+            return element.kind === 'parameter';
+        }
     };
 }

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -5,7 +5,21 @@ export default class Guard {
      * Guards for types from `jsdoc` doclets.
      */
     static doclet = class {
-
+        /**
+         * Guards that the given `doclet` is of type `IDocletProp`.
+         *
+         * @param {any | IDocletProp} doclet
+         *
+         * @return {doclet is IDocletProp}
+         */
+        static isIDocletProp(doclet: any | IDocletProp): doclet is IDocletProp {
+            return typeof doclet === 'object'
+                   && 'type' in doclet
+                   && 'name' in doclet
+                   && 'description' in doclet
+                   && 'comment' in doclet
+                   && typeof doclet.type === 'object';
+        }
     };
 
     /**

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -16,8 +16,6 @@ export default class Guard {
             return typeof doclet === 'object'
                    && 'type' in doclet
                    && 'name' in doclet
-                   && 'description' in doclet
-                   && 'comment' in doclet
                    && typeof doclet.type === 'object';
         }
     };

--- a/tsgen/src/Guard.ts
+++ b/tsgen/src/Guard.ts
@@ -18,6 +18,19 @@ export default class Guard {
                    && 'name' in doclet
                    && typeof doclet.type === 'object';
         }
+
+        /**
+         * Guards that the given `doclet` is of type `IMemberDoclet`.
+         *
+         * @param {any | TDoclet} doclet
+         *
+         * @return {doclet is IMemberDoclet}
+         */
+        static isIMemberDoclet(doclet: object | TDoclet): doclet is IMemberDoclet {
+            return typeof doclet === 'object'
+                   && 'kind' in doclet
+                   && (doclet.kind === 'constant' || doclet.kind === 'member');
+        }
     };
 
     /**

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -587,7 +587,8 @@ export class Parser {
     }
 
     /**
-     * Processes the flags for a `IMemberDoclet`-type `doclet`, ensuring those flags are properly applied to the `domObj`.
+     * Processes the flags for a {@link IMemberDoclet `IMemberDoclet`}-type `doclet`,
+     * ensuring those flags are properly applied to the `domObj`.
      *
      * @param {Readonly<IMemberDoclet>} doclet
      * @param {DeclarationBase | Parameter} domObj
@@ -599,11 +600,14 @@ export class Parser {
         doclet: Readonly<IMemberDoclet>,
         domObj: dom.DeclarationBase | dom.Parameter
     ): void {
-        if (doclet.readonly || doclet.kind === 'constant') domObj.flags |= dom.DeclarationFlags.ReadOnly;
+        if (doclet.readonly || doclet.kind === 'constant') {
+            domObj.flags |= dom.DeclarationFlags.ReadOnly;
+        }
     }
 
     /**
-     * Processes the flags for a `TDoclet`-type `doclet`, ensuring those flags are properly applied to the `domObj`.
+     * Processes the flags for a {@link TDoclet `TDoclet`}-type `doclet`,
+     * ensuring those flags are properly applied to the `domObj`.
      *
      * @param {Readonly<TDoclet>} doclet
      * @param {DeclarationBase | Parameter} domObj
@@ -624,11 +628,14 @@ export class Parser {
                 break;
         }
 
-        if (doclet.scope === 'static') domObj.flags |= dom.DeclarationFlags.Static;
+        if (doclet.scope === 'static') {
+            domObj.flags |= dom.DeclarationFlags.Static;
+        }
     }
 
     /**
-     * Processes the flags for a `IDocletProp`-type `doclet`, ensuring those flags are properly applied to the `domObj`.
+     * Processes the flags for a {@link IDocletProp `IDocletProp`}-type `doclet`,
+     * ensuring those flags are properly applied to the `domObj`.
      *
      * @param {Readonly<IDocletProp>} doclet
      * @param domObj
@@ -640,17 +647,17 @@ export class Parser {
         doclet: Readonly<IDocletProp>,
         domObj: dom.DeclarationBase | dom.Parameter
     ): void {
-        if (doclet.variable === true) {
+        if (doclet.variable) {
             if (!Guard.dom.isParameter(domObj)) {
                 throw new Error('doclet marked as variable doesn\'t have "parameter" kind dom element');
-            } // ensure that it's a type that actually has a 'type' property.
+            } // ensures that it's a type that actually has a 'type' property.
 
             domObj.flags |= dom.ParameterFlags.Rest;
 
             const type = domObj.type;
             if (!Guard.dom.type.isNamedTypeReference(type) && !Guard.dom.type.isTypeParameter(type)) {
                 throw new Error('"variable" doclet dom.Parameter.type isn\'t of the correct kind');
-            } // ensure that it's a type that actually has a 'name' property
+            } // ensures that it's a type that actually has a 'name' property
 
             /*
                 TODO: what if you want a 2+d array?
@@ -676,17 +683,21 @@ export class Parser {
                         > I think the jsdocs then parsed the type wrongly or something.
                         > Ah right. Yes, if you did rest param but the jsdoc was defined as non array, you couldn't put in more stuff... Or something like that.
                  */
-                if (type.name != 'any')
-                // @ts-ignore TODO: IDocletProp doesn't have a longname property - find an alternative
+                if (type.name != 'any') {
+                    // @ts-ignore TODO: IDocletProp doesn't have a longname property - find an alternative
                     console.log(`Warning: rest parameter should be an array type for ${doclet.longname}`);
-                type.name = type.name + '[]'; // Must be an array
+                }
+
+                type.name += '[]'; // Must be an array
             }
-        } else if (doclet.optional === true) {// Rest implies Optional – no need to flag it as such
-            if (Guard.dom.isParameter(domObj)) {
-                domObj.flags |= dom.ParameterFlags.Optional;
-            } else {
-                domObj.flags |= dom.DeclarationFlags.Optional;
-            }
+
+            return;
+        } // Rest implies Optional, & it's illegal in TS to mark both.
+
+        if (doclet.optional) {
+            domObj.flags |= Guard.dom.isParameter(domObj)
+                ? dom.ParameterFlags.Optional
+                : dom.DeclarationFlags.Optional;
         }
     }
 

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -553,19 +553,25 @@ export class Parser {
         return name;
     }
 
+    /**
+     * Processes the flags on the given `doclet`, ensuring those flags are properly applied to the `domObj`.
+     *
+     * @param {IDocletProp | IDocletBase | IMemberDoclet} doclet
+     * @param {DeclarationBase | Parameter} domObj
+     */
     private processFlags(
         doclet:
             | IDocletProp
             | IDocletBase
             | IMemberDoclet,
-        obj: dom.DeclarationBase | dom.Parameter
+        domObj: dom.DeclarationBase | dom.Parameter
     ): void {
         // TODO: break this method up, so that it works better with typings
-        obj.flags = dom.DeclarationFlags.None;
+        domObj.flags = dom.DeclarationFlags.None;
         if ('variable' in doclet || 'optional' in doclet) {
             if (doclet.variable === true) {
-                obj.flags |= dom.ParameterFlags.Rest;
-                let type: any = (<dom.Parameter>obj).type;
+                domObj.flags |= dom.ParameterFlags.Rest;
+                let type: any = (<dom.Parameter>domObj).type;
                 if (!type.name.endsWith('[]')) {
                     if (type.name != 'any')
                     // @ts-ignore TODO: IDocletProp doesn't have a longname property - find an alternative
@@ -573,25 +579,25 @@ export class Parser {
                     type.name = type.name + '[]'; // Must be an array
                 }
             } else if (doclet.optional === true) {// Rest implies Optional – no need to flag it as such
-                if (obj['kind'] === 'parameter') obj.flags |= dom.ParameterFlags.Optional;
-                else obj.flags |= dom.DeclarationFlags.Optional;
+                if (domObj['kind'] === 'parameter') domObj.flags |= dom.ParameterFlags.Optional;
+                else domObj.flags |= dom.DeclarationFlags.Optional;
             }
         }
         if ('access' in doclet || 'scope' in doclet) {
             switch (doclet.access) {
                 case 'protected':
-                    obj.flags |= dom.DeclarationFlags.Protected;
+                    domObj.flags |= dom.DeclarationFlags.Protected;
                     break;
                 case 'private':
-                    obj.flags |= dom.DeclarationFlags.Private;
+                    domObj.flags |= dom.DeclarationFlags.Private;
                     break;
             }
 
-            if (doclet.scope === 'static') obj.flags |= dom.DeclarationFlags.Static;
+            if (doclet.scope === 'static') domObj.flags |= dom.DeclarationFlags.Static;
         }
 
         if ('readonly' in doclet || 'kind' in doclet) {
-            if (doclet.readonly || doclet.kind === 'constant') obj.flags |= dom.DeclarationFlags.ReadOnly;
+            if (doclet.readonly || doclet.kind === 'constant') domObj.flags |= dom.DeclarationFlags.ReadOnly;
         }
     }
 

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -1,4 +1,5 @@
 import * as dom from 'dts-dom';
+import Guard from './Guard';
 
 const regexEndLine = /^(.*)\r\n|\n|\r/gm;
 
@@ -566,38 +567,57 @@ export class Parser {
             | IMemberDoclet,
         domObj: dom.DeclarationBase | dom.Parameter
     ): void {
-        // TODO: break this method up, so that it works better with typings
         domObj.flags = dom.DeclarationFlags.None;
-        if ('variable' in doclet || 'optional' in doclet) {
+
+        if (Guard.doclet.isIDocletProp(doclet)) {
             if (doclet.variable === true) {
+                if (!Guard.dom.isParameter(domObj)) {
+                    throw new Error('doclet marked as variable doesn\'t have "parameter" kind dom element');
+                } // ensure that it's a type that actually has a 'type' property.
+
                 domObj.flags |= dom.ParameterFlags.Rest;
-                let type: any = (<dom.Parameter>domObj).type;
+
+                const type = domObj.type;
+                if (!Guard.dom.type.isNamedTypeReference(type) && !Guard.dom.type.isTypeParameter(type)) {
+                    throw new Error('"variable" doclet dom.Parameter.type isn\'t of the correct kind');
+                } // ensure that it's a type that actually has a 'name' property
+
+                /*
+                    TODO: what if you want a 2+d array?
+                        Currently, if you do "...T[]", that'll become "...T[]" in the typings.
+
+                    I can't find anywhere in jsdoc about adding `[]` to rest parameters,
+                    leading me to believe the above should actually become "...T[][]".
+
+                    Note this happens even if you use `...Array<T>`, b/c `Array<T>` is
+                    transformed elsewhere into `...T[]`.
+
+                    Ideally, this should be written up as a 'parser rule' somewhere.
+                 */
                 if (!type.name.endsWith('[]')) {
+                    /*
+                        TODO: is this still needed?
+                            Types seem to be generated correctly even if not '...*'. maybe it was for object properties?
+
+                        I can't seem to create a jsdoc where this actually has problems.
+
+                            Asked @antriel about it:
+                                > I remember there was a reason for that. Just not sure what.
+                                > I think the jsdocs then parsed the type wrongly or something.
+                                > Ah right. Yes, if you did rest param but the jsdoc was defined as non array, you couldn't put in more stuff... Or something like that.
+                         */
                     if (type.name != 'any')
                     // @ts-ignore TODO: IDocletProp doesn't have a longname property - find an alternative
                         console.log(`Warning: rest parameter should be an array type for ${doclet.longname}`);
                     type.name = type.name + '[]'; // Must be an array
                 }
             } else if (doclet.optional === true) {// Rest implies Optional – no need to flag it as such
-                if (domObj['kind'] === 'parameter') domObj.flags |= dom.ParameterFlags.Optional;
-                else domObj.flags |= dom.DeclarationFlags.Optional;
+                if (Guard.dom.isParameter(domObj)) {
+                    domObj.flags |= dom.ParameterFlags.Optional;
+                } else {
+                    domObj.flags |= dom.DeclarationFlags.Optional;
+                }
             }
-        }
-        if ('access' in doclet || 'scope' in doclet) {
-            switch (doclet.access) {
-                case 'protected':
-                    domObj.flags |= dom.DeclarationFlags.Protected;
-                    break;
-                case 'private':
-                    domObj.flags |= dom.DeclarationFlags.Private;
-                    break;
-            }
-
-            if (doclet.scope === 'static') domObj.flags |= dom.DeclarationFlags.Static;
-        }
-
-        if ('readonly' in doclet || 'kind' in doclet) {
-            if (doclet.readonly || doclet.kind === 'constant') domObj.flags |= dom.DeclarationFlags.ReadOnly;
         }
     }
 

--- a/tsgen/src/types/jsdoc.d.ts
+++ b/tsgen/src/types/jsdoc.d.ts
@@ -33,7 +33,6 @@ declare interface IDocletProp {
     type: IDocletType;
     name: string;
     description: string;
-    comment: string;
     defaultvalue?: string;
     meta?: any;
     optional?: boolean;

--- a/tsgen/src/types/jsdoc.d.ts
+++ b/tsgen/src/types/jsdoc.d.ts
@@ -32,7 +32,7 @@ declare interface IDocletType {
 declare interface IDocletProp {
     type: IDocletType;
     name: string;
-    description: string;
+    description?: string;
     defaultvalue?: string;
     meta?: any;
     optional?: boolean;


### PR DESCRIPTION
Break up `processFlags` method into bits, making sure it's strongly typed & making it easier to iterate on when making future improvements.