### PR TITLE
Cleanup/cleanup prepare type name method

### DIFF
--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -517,6 +517,30 @@ export class Parser {
         }
     }
 
+    /**
+     * Prepares the `name` of a type so that it can be used to create a {@link NamedTypeReference}.
+     *
+     * Preparing involves replacing '*' with 'any', and removing '.' from generics.
+     *
+     * The return of this method is expected to be used with the {@link create#namedTypeReference} method.
+     *
+     * @examples
+     *  "*" => "any"
+     *  "Array.<*>" => "Array<any>"
+     *  "Array.<string>" => "Array<string>"
+     *  "Object.<string, *>" => "Object<string, any>"
+     *  "Array.<Array.<integer>>" => "Array<Array<integer>>"
+     *  "Array.<Array.<Phaser.Tilemaps.Tile>>" => "Array<Array<Phaser.Tilemaps.Tile>>"
+     *  "Phaser.Structs.Set.<T>" => "Phaser.Structs.Set<T>"
+     *  "Phaser.Structs.Map.<K, V>" => "Phaser.Structs.Map<K, V>"
+     *
+     * @param {string} name
+     *
+     * @return {string}
+     * @private
+     *
+     * @instance
+     */
     private _prepareTypeName(name: string): string {
         if (name.indexOf('*') != -1) {
             name = (<string>name).split('*').join('any');

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -543,8 +543,8 @@ export class Parser {
      */
     private _prepareTypeName(name: string): string {
         return name
-            .split('*').join('any')
-            .split('.<').join('<');
+            .replace(/\*/g, 'any')
+            .replace(/\.</g, '<');
     }
 
     private processTypeName(name: string): string {

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -263,7 +263,7 @@ export class Parser {
             // resolve augments
             if (doclet.augments && doclet.augments.length) {
                 for (let augment of doclet.augments) {
-                    let name: string = this.prepareTypeName(augment);
+                    let name: string = this._prepareTypeName(augment);
 
                     let wrappingName = name.match(/[^<]+/s)[0];//gets everything up to a first < (to handle augments with type parameters)
 
@@ -506,7 +506,7 @@ export class Parser {
             let types = [];
             for (let name of typeDoc.type.names) {
 
-                name = this.prepareTypeName(name);
+                name = this._prepareTypeName(name);
 
                 let type = dom.create.namedTypeReference(this.processTypeName(name));
 
@@ -517,7 +517,7 @@ export class Parser {
         }
     }
 
-    private prepareTypeName(name: string): string {
+    private _prepareTypeName(name: string): string {
         if (name.indexOf('*') != -1) {
             name = (<string>name).split('*').join('any');
         }
@@ -725,7 +725,7 @@ export class Parser {
                     handleOverrides(matches[3], matches[2]);
                 } else if (tag.originalTitle === 'genericUse') {
                     let matches = tag.value.match(/(?:(?:{)([^}]+)(?:}))(?:\s?-\s?(?:\[)(.+)(?:\]))?/);
-                    let overrideType: string = this.prepareTypeName(matches[1]);
+                    let overrideType: string = this._prepareTypeName(matches[1]);
 
                     handleOverrides(matches[2], this.processTypeName(overrideType));
                 }

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -542,13 +542,9 @@ export class Parser {
      * @instance
      */
     private _prepareTypeName(name: string): string {
-        if (name.indexOf('*') != -1) {
-            name = (<string>name).split('*').join('any');
-        }
-        if (name.indexOf('.<') != -1) {
-            name = (<string>name).split('.<').join('<');
-        }
-        return name;
+        return name
+            .split('*').join('any')
+            .split('.<').join('<');
     }
 
     private processTypeName(name: string): string {


### PR DESCRIPTION
Cleaned up the `prepareTypeName` method, so that it's documented and efficient.