### PR TITLE
Cleanup/parse type method

### DIFF
--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -502,12 +502,12 @@ export class Parser {
      * @return {Type}
      */
     private parseType(
-        typeDoc?:
+        typeDoc:
             | IMemberDoclet
             | IDocletProp
             | IDocletReturn
     ): dom.Type {
-        if (!typeDoc || !typeDoc.type) {
+        if (!typeDoc.type) {
             return dom.type.any;
         } else {
             let types = [];

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -509,19 +509,19 @@ export class Parser {
     ): dom.Type {
         if (!typeDoc.type) {
             return dom.type.any;
-        } else {
-            let types = [];
-            for (let name of typeDoc.type.names) {
-
-                name = this._prepareTypeName(name);
-
-                let type = dom.create.namedTypeReference(this.processTypeName(name));
-
-                types.push(type);
-            }
-            if (types.length == 1) return types[0];
-            else return dom.create.union(types);
         }
+
+        let types = [];
+        for (let name of typeDoc.type.names) {
+
+            name = this._prepareTypeName(name);
+
+            let type = dom.create.namedTypeReference(this.processTypeName(name));
+
+            types.push(type);
+        }
+        if (types.length == 1) return types[0];
+        else return dom.create.union(types);
     }
 
     /**

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -511,12 +511,11 @@ export class Parser {
             return dom.type.any;
         }
 
-        let types = [];
+        const types = [];
         for (let name of typeDoc.type.names) {
-
             name = this._prepareTypeName(name);
 
-            let type = dom.create.namedTypeReference(this.processTypeName(name));
+            const type = dom.create.namedTypeReference(this.processTypeName(name));
 
             types.push(type);
         }

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -519,7 +519,8 @@ export class Parser {
 
             types.push(type);
         }
-        if (types.length == 1) {
+
+        if (types.length === 1) {
             return types[0];
         }
 

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -335,7 +335,7 @@ export class Parser {
     }
 
     private createMember(doclet: IMemberDoclet): dom.PropertyDeclaration {
-        let type = this.parseType(doclet);
+        let type = this._parseType(doclet);
 
         let obj = dom.create.property(doclet.name, type);
 
@@ -354,7 +354,7 @@ export class Parser {
      * @return {PropertyDeclaration}
      */
     private createProp(doclet: IDocletProp): dom.PropertyDeclaration {
-        let type = this.parseType(doclet);
+        let type = this._parseType(doclet);
 
         let obj = dom.create.property(doclet.name, type);
 
@@ -387,7 +387,7 @@ export class Parser {
         let returnType: dom.Type = dom.type.void;
 
         if (doclet.returns) {
-            returnType = this.parseType(doclet.returns[0]);
+            returnType = this._parseType(doclet.returns[0]);
         }
 
         let obj = dom.create.function(doclet.name, null, returnType);
@@ -470,7 +470,7 @@ export class Parser {
                 }
                 ///////////////////////
 
-                let param = dom.create.parameter(paramDoc.name, this.parseType(paramDoc));
+                let param = dom.create.parameter(paramDoc.name, this._parseType(paramDoc));
                 parameters.push(param);
 
                 if (optional && paramDoc.optional != true) {
@@ -501,7 +501,7 @@ export class Parser {
      *
      * @return {Type}
      */
-    private parseType(
+    private _parseType(
         typeDoc:
             | IMemberDoclet
             | IDocletProp

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -511,14 +511,10 @@ export class Parser {
             return dom.type.any;
         }
 
-        const types = [];
-        for (let name of typeDoc.type.names) {
-            name = this._prepareTypeName(name);
-
-            const type = dom.create.namedTypeReference(this.processTypeName(name));
-
-            types.push(type);
-        }
+        const types = typeDoc.type.names
+                             .map(name => this._prepareTypeName(name))
+                             .map(name => this.processTypeName(name))
+                             .map(dom.create.namedTypeReference);
 
         if (types.length === 1) {
             return types[0];

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -500,6 +500,7 @@ export class Parser {
      * @param {IMemberDoclet | IDocletProp | IDocletReturn} typeDoc
      *
      * @return {Type}
+     * @private
      */
     private _parseType(
         typeDoc:

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -494,6 +494,13 @@ export class Parser {
         obj.parameters = parameters;
     }
 
+    /**
+     * Parses the given `typeDoc`, returning the correct `Type` to use for TypeScript.
+     *
+     * @param {IMemberDoclet | IDocletProp | IDocletReturn} typeDoc
+     *
+     * @return {Type}
+     */
     private parseType(
         typeDoc?:
             | IMemberDoclet

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -503,9 +503,9 @@ export class Parser {
      */
     private _parseType(
         typeDoc:
-            | IMemberDoclet
-            | IDocletProp
-            | IDocletReturn
+            | Readonly<IMemberDoclet>
+            | Readonly<IDocletProp>
+            | Readonly<IDocletReturn>
     ): dom.Type {
         if (!typeDoc.type) {
             return dom.type.any;

--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -520,8 +520,11 @@ export class Parser {
 
             types.push(type);
         }
-        if (types.length == 1) return types[0];
-        else return dom.create.union(types);
+        if (types.length == 1) {
+            return types[0];
+        }
+
+        return dom.create.union(types);
     }
 
     /**

--- a/tsgen/src/types/jsdoc.d.ts
+++ b/tsgen/src/types/jsdoc.d.ts
@@ -120,7 +120,7 @@ declare interface IMemberDoclet extends IDocletBase {
     kind: 'member' | 'constant';
     readonly: boolean;
     isEnum: boolean;
-    type: IDocletType;
+    type?: IDocletType;
 }
 
 declare interface INamespaceDoclet extends IDocletBase {


### PR DESCRIPTION
Cleans up the `parseType` method, giving it documentation and using `.map` instead of a for-loop.